### PR TITLE
Add tool 7: Create basalt boxes

### DIFF
--- a/Source/UnrealSandboxTerrain/Public/SandboxTerrainController.h
+++ b/Source/UnrealSandboxTerrain/Public/SandboxTerrainController.h
@@ -155,6 +155,8 @@ public:
 
 	void digTerrainCubeHole(FVector origin, float r, float strength);
 
+	void fillTerrainCubeHole(FVector origin, const float r, const float strength, const int matId);
+
 	void fillTerrainRound(const FVector origin, const float r, const float strength, const int matId);
 
 	FVector GetZoneIndex(FVector v);


### PR DESCRIPTION
Playing around with UE4VoxelTerrain today and decided to add a tool to fill cubes in a similar way in which they can be removed. Implemented it fairly easily (I'm definitely a EU4 beginner) and had some fun making small mazes.

Not sure if you're accepting pull requests or want such a change. I've had some fun with it and thought to share. 

A PR for UE4VoxelTerrain will follow shortly.